### PR TITLE
Added loading spinner while initializing

### DIFF
--- a/MetFamily/R/R_packages.R
+++ b/MetFamily/R/R_packages.R
@@ -1,22 +1,5 @@
 
 ##############################################################################################################
-## GUI
-#install.packages("shiny")
-library("shiny")
-#devtools::install_github("rstudio/htmltools")
-library("htmltools")
-#install.packages("shinyjs")
-library("shinyjs")
-#install.packages("DT")
-library("DT")
-#install.packages("colourpicker")
-library("colourpicker")
-#install.packages("shinyBS")
-library("shinyBS")
-#install.packages("shinybusy")
-library("shinybusy")
-
-##############################################################################################################
 ## mass spectrometry
 #sudo apt-get install libnetcdf-dev
 #source("https://bioconductor.org/biocLite.R")

--- a/MetFamily/server.R
+++ b/MetFamily/server.R
@@ -71,7 +71,6 @@ getFile <- function(files){
 ## source code
 getSourceFileNames <- function(){
   return(c(
-    "R_packages.R",
     "FragmentMatrixFunctions.R",
     "DataProcessing.R",
     "TreeAlgorithms.R",
@@ -111,6 +110,7 @@ sourceTheCode()
 shinyServer(
   func = function(input, output, session) {
     show_modal_spinner(spin = "self-building-square", text="Loading libraries")
+    source(getFile("R_packages.R"))
     #########################################################################################
     #########################################################################################
     ## global variables per user

--- a/MetFamily/ui.R
+++ b/MetFamily/ui.R
@@ -4,6 +4,9 @@ library(shiny)
 library(shinyBS)
 library(shinyjs)
 library(DT)
+library(colourpicker)
+library(shinybusy)
+
 
 ipbfooter <- HTML(readLines("www/ipbfooter.html"))
 


### PR DESCRIPTION
This PR provides a loading spinner while initializing MetFamily. 
The timing is still not perfect, but it is more sophisticated than a blank screen. 
Furthermore, this PR avoids loading UI libraries twice (in server and UI). 
The disadvantage is that the shared R session will try to load the libraries for every new user again, but as far as I know, this should not result in much overhead when the libraries are already present.  

<img width="1656" alt="Bildschirmfoto 2020-06-30 um 16 58 56" src="https://user-images.githubusercontent.com/2099798/86143482-c5b54800-baf4-11ea-8466-0e8c75cd262b.png">
