### PR TITLE
Read qfeatures fix #88

### DIFF
--- a/R/DataProcessing.R
+++ b/R/DataProcessing.R
@@ -758,19 +758,22 @@ readProjectData <- function(fileLines, progress = FALSE)
 #'
 #' @returns The dataList object with added sirius annotations.
 #' @export
-add_qfeatures <- function(dataList, qfeatures, fileAnnotation) {
+add_qfeatures <- function(dataList, qfeatures, fileAnnotation = NULL) {
   # This function takes snippets previously in convertToProjectFile and readProjectData
   # to streamline the process de declutter the aforementionned functions.
   
+  # The function does not do anything without annotation file
+  if (is.null(fileAnnotation)) {
+    return(dataList)
+  }
+  
   metaboliteProfile <- dataList$dataFrameInfos
   
-  qfeatures <- addSiriusAnnotations(qfeatures, fileAnnotation)
-  
+  # previously used test, not sure if still needed
   if (is.null(attr(rowData(qfeatures[[1]]), "annotation column"))) {
     stop("No annotation")
   }
-  
-  
+
   #Start of importing  annotation part1 from two
   
   # Extract the relevant data: Alignment ID and the annotation column from qfeatures

--- a/R/DataProcessing.R
+++ b/R/DataProcessing.R
@@ -80,7 +80,7 @@ readClusterDataFromProjectFile <- function(file, progress = FALSE)
   )
   base::close(con = file)
 
-  dataList <- readProjectData(fileLines = fileLines, progress = progress, qfeatures = qfeatures)
+  dataList <- readProjectData(fileLines = fileLines, progress = progress)
   fileLines <- NULL
   
   return(dataList)
@@ -98,7 +98,7 @@ readClusterDataFromProjectFile <- function(file, progress = FALSE)
 #' @export
 #'
 #' @examples
-readProjectData <- function(fileLines, progress = FALSE, qfeatures = NULL)
+readProjectData <- function(fileLines, progress = FALSE)
 {
   allowedTags <- c("ID")
   allowedTagPrefixes <- c("AnnotationColors=")
@@ -196,43 +196,7 @@ readProjectData <- function(fileLines, progress = FALSE, qfeatures = NULL)
   listMatrixRows <- NULL
   listMatrixCols <- NULL
 
-  
-  ################################################################################
-  #Start of importing  annotation part1 from two
-  # Display the message and give the user the option to choose whether to upload the annotation file or not. 
-  #If Y shows selection window for annotation file. if N ignores annotation process
-  #message("Do you want to upload the annotation file? (Y/N)")
-  #user_choice <- readline()
-  
-  ######debugging
-  tryCatch(
-    {
-      rowData(qfeatures)
-    },
-    error = function(e) {
-      message("Error: ", e$message)
-      traceback()
-    }
-  )
-  ######debugging
- 
-  if (!is.null(attr(rowData(qfeatures[[1]]), "annotation column"))) {
-    
-    # Extract the relevant data: Alignment ID and the annotation column from qfeatures
-    annot_colname <- attr(rowData(qfeatures[[1]]), "annotation column")
-    annotation_data <- rowData(qfeatures[[1]])[[annot_colname]]
-    alignment_ids <- rowData(qfeatures[[1]])[["Alignment ID"]]
-    
-    # Find the matching indices between metaboliteProfile and annotation_data
-    matching_indices <- match(metaboliteProfile[["Alignment ID"]], alignment_ids)
-    
-    metaboliteProfile$Annotation[!is.na(matching_indices)] <- annotation_data[matching_indices[!is.na(matching_indices)]] 
-    #eliminate NAs replace by "" so nchar(annoVals[[i]]) > 0 works in l. 597
-    metaboliteProfile$Annotation[is.na(metaboliteProfile$Annotation)] <- "" 
-  }
-  
-  #####################################################################################################################################
-  #end of importing  annotation part1 from two
+  # gp: Previous location of "Start of importing annotation part1 from two"
   
   listMatrixVals <- NULL
   
@@ -291,34 +255,7 @@ readProjectData <- function(fileLines, progress = FALSE, qfeatures = NULL)
     dataFrameHeader[3, target + 1] <- annotationColumnName
   }
 
-  ## STN: Disabled. 
-  if (!is.null(attr(rowData(qfeatures[[1]]), "annotation column"))) {
-  #Start of importing annotation part2 from two
-  ################################################################################
-   #adding HEX color codes from external annotations to the annotationColorsMapInitValue of dataFrameHeader
-
-      # Copy the selected column by user, Remove duplicates and exclude the first row
-    uniqueAnnotations <- unique(unlist(strsplit(metaboliteProfile$Annotation, ",")))
-    ###Debug
-    print("Unique Annotations Before Filtering:")
-    print(uniqueAnnotations)
-    ###/Debug
-    uniqueAnnotations <- paste0(uniqueAnnotations, "=")
-    # Add a random string from the hex color list to each element of uniqueAnnotions
-    # strings_list <- c("#000000", "#FFFFFF", "#FF0000", "#00FF00", "#0000FF", "#FFFF00", "#FF00FF", "#00FFFF", "#800000", "#008000", "#000080", "#808000", "#800080", "#008080", "#808080", "#C0C0C0", "#FFA500", "#FFC0CB", "#FFD700", "#A52A2A")
-    # uniqueAnnotations <- paste0(uniqueAnnotations, sample(strings_list, length(uniqueAnnotations), replace = TRUE))
-    allowedCols <- c("blue", "red", "yellow", "green", "brown", "deepskyblue", "orange", "deeppink", "aquamarine", "burlywood", "cadetblue", "coral", "cornflowerblue", "cyan", "firebrick", "goldenrod", "indianred", "khaki", "magenta", "maroon", "beige", "moccasin", "olivedrab", "orangered", "orchid", "paleturquoise3", "rosybrown", "salmon", "seagreen3", "skyblue", "steelblue", "#BF360C", "#33691E", "#311B92", "#880E4F", "#1A237E", "#006064", "#004D40", "#FF6F00", "#E65100")
-    uniqueAnnotations <- paste0(uniqueAnnotations, sample(allowedCols, length(uniqueAnnotations), replace = TRUE))
-    # Format uniqueAnnotations into a single line with comma-separated values
-    uniqueAnnotations1 <- paste(uniqueAnnotations, collapse = ", ")
-    #uniqueAnnotationsHexs <- paste("AnnotationColors={", paste(uniqueAnnotations1, collapse = ","), "}")# this line introduces a space after the first Item of the object, therefore, replaced with the following to remove the space
-    uniqueAnnotationsHexs <- gsub("AnnotationColors=\\{\\s+", "AnnotationColors={", paste("AnnotationColors={", paste(uniqueAnnotations1, collapse = ","), "}"))
-    # Assuming dataFrameHeader is your data frame
-    dataFrameHeader$Annotation[2] <- uniqueAnnotationsHexs
-  
-################################################################################
-#End of importing  annotation part2 from two
-  }
+  # gp: Previous location of "Start of importing annotation part2 from two"
   
   annotationColumnIndex <- which(metaboliteProfileColumnNames == annotationColumnName)
   annotationColorsValue <- dataFrameHeader[2, annotationColumnIndex]

--- a/R/DataProcessing.R
+++ b/R/DataProcessing.R
@@ -105,11 +105,13 @@ readProjectData <- function(fileLines, progress = FALSE)
   
   ##################################################################################################
   ## parse data
-  if(!is.na(progress))  
-    if(progress)  
+  if(!is.na(progress)) {
+    if(progress) {  
       incProgress(amount = 0.1, detail = "Preprocessing") 
-  else 
+    }
+  } else { 
     print("Preprocessing")
+  }
   
   numberOfRows <- length(fileLines)
   numberOfMS1features <- as.integer(numberOfRows - 3)
@@ -145,9 +147,10 @@ readProjectData <- function(fileLines, progress = FALSE)
   fragmentGroupsAverageMass <- as.numeric(line3Tokens[fragmentMatrixStart:numberOfColumns])
   line3Tokens <- NULL
   
-  if(any(duplicated(metaboliteProfileColumnNames)))
+  if(any(duplicated(metaboliteProfileColumnNames))) {
     stop(paste("Duplicated column names in the metabolite profile: ", 
                paste(sort(unique(metaboliteProfileColumnNames[duplicated(metaboliteProfileColumnNames)])), collapse = "; ")))
+  }
   
   #########################################################################
   ## extract metabolite profile and fragment matrix
@@ -270,12 +273,13 @@ readProjectData <- function(fileLines, progress = FALSE)
   rts <- metaboliteProfile[, "RT"]
   
   ## add .0 if necessary
-  for(i in seq_len(numberOfMS1features))
-    if(length(grep(x = mzs[[i]], pattern = ".*\\..*")) == 0)
-      mzs[[i]] <- paste(mzs[[i]], ".0", sep = "")
-  for(i in seq_len(numberOfMS1features))
-    if(length(grep(x = rts[[i]], pattern = ".*\\..*")) == 0)
-      rts[[i]] <- paste(rts[[i]], ".0", sep = "")
+  for(i in seq_len(numberOfMS1features)) {
+    if(length(grep(x = mzs[[i]], pattern = ".*\\..*")) == 0) {
+      mzs[[i]] <- paste(mzs[[i]], ".0", sep = "") }}
+  
+  for(i in seq_len(numberOfMS1features)) {
+    if(length(grep(x = rts[[i]], pattern = ".*\\..*")) == 0) {
+      rts[[i]] <- paste(rts[[i]], ".0", sep = "") }}
   
   regexResult <- gregexpr(pattern = "^(?<before>\\d+)\\.(?<after>\\d+)$", text = mzs, perl = TRUE)
   mzStartsBefore  <- unlist(lapply(X = regexResult, FUN = function(x){attr(x = x, which = "capture.start")[[1]]}))
@@ -299,6 +303,7 @@ readProjectData <- function(fileLines, progress = FALSE)
   maximumNumberOfDecimalPlacesForMz <- 3
   maximumNumberOfDecimalPlacesForRt <- 2
   
+  # TODO document this block
   for(idx in seq_along(mzs)){
     mzStartBefore  <- mzStartsBefore [[idx]]
     mzStartAfter   <- mzStartsAfter  [[idx]]
@@ -316,35 +321,36 @@ readProjectData <- function(fileLines, progress = FALSE)
     rtBefore <- substr(start = rtStartBefore, stop = rtStartBefore + rtLengthBefore - 1, x = rts[[idx]])
     rtAfter  <- substr(start = rtStartAfter,  stop = rtStartAfter  + rtLengthAfter  - 1, x = rts[[idx]])
     
-    if(nchar(mzBefore) < mzMaxBefore) 
+    if(nchar(mzBefore) < mzMaxBefore) {
       mzBefore <- paste(
         paste(rep(x = "  ", times = mzMaxBefore - nchar(mzBefore)), collapse = ""),
         mzBefore,
-        sep = ""
-      )
-    if(nchar(mzAfter) > maximumNumberOfDecimalPlacesForMz)
+        sep = "")
+    }
+    if(nchar(mzAfter) > maximumNumberOfDecimalPlacesForMz) {
       mzAfter <- substr(x = mzAfter, start = 1, stop = maximumNumberOfDecimalPlacesForMz)
-    if(nchar(mzAfter) < maximumNumberOfDecimalPlacesForMz)
+    }
+    if(nchar(mzAfter) < maximumNumberOfDecimalPlacesForMz) {
       mzAfter <- paste(
         mzAfter,
         paste(rep(x = "0", times = maximumNumberOfDecimalPlacesForMz - nchar(mzAfter)), collapse = ""),
-        sep = ""
-      )
-    
-    if(nchar(rtBefore) < rtMaxBefore) 
+        sep = "")
+    }
+    if(nchar(rtBefore) < rtMaxBefore) {
       rtBefore <- paste(
         paste(rep(x = "  ", times = rtMaxBefore - nchar(rtBefore)), collapse = ""),
         rtBefore,
-        sep = ""
-      )
-    if(nchar(rtAfter) > maximumNumberOfDecimalPlacesForRt)
+        sep = "")
+    }
+    if(nchar(rtAfter) > maximumNumberOfDecimalPlacesForRt) {
       rtAfter <- substr(x = rtAfter, start = 1, stop = maximumNumberOfDecimalPlacesForRt)
-    if(nchar(rtAfter) < maximumNumberOfDecimalPlacesForRt)
+    }
+    if(nchar(rtAfter) < maximumNumberOfDecimalPlacesForRt) {
       rtAfter <- paste(
         rtAfter,
         paste(rep(x = "0", times = maximumNumberOfDecimalPlacesForRt - nchar(rtAfter)), collapse = ""),
-        sep = ""
-      )
+        sep = "")
+    }
     
     mzs[[idx]] <- paste(mzBefore, mzAfter, sep = ".")
     rts[[idx]] <- paste(rtBefore, rtAfter, sep = ".")
@@ -422,8 +428,9 @@ readProjectData <- function(fileLines, progress = FALSE)
   ## featureIndexMatrix
   featureIndexMatrix <- matrix(nrow = numberOfMS1features, ncol = max(sapply(X = featureIndeces, FUN = length)))
   rownames(featureIndexMatrix) <- precursorLabels
-  for(i in seq_len(numberOfMS1features))
+  for(i in seq_len(numberOfMS1features)) {
     featureIndexMatrix[i, seq_len(length(featureIndeces[[i]]))] <- featureIndeces[[i]]
+  }
   
   minimumMass <- min(fragmentGroupsAverageMass)
   maximumMass <- max(fragmentGroupsAverageMass)
@@ -433,10 +440,12 @@ readProjectData <- function(fileLines, progress = FALSE)
   
   ## sample columns
   sampleColumns <- tagsSector != ""
-  for(allowedTag in allowedTags)
+  for(allowedTag in allowedTags) {
     sampleColumns[grep(x = tagsSector, pattern = paste("^", allowedTag, "$", sep = ""))] <- FALSE
-  for(allowedTagPrefix in allowedTagPrefixes)
+  }
+  for(allowedTagPrefix in allowedTagPrefixes) {
     sampleColumns[grep(x = tagsSector, pattern = paste("^", allowedTagPrefix, sep = ""))] <- FALSE
+  }
   sampleColumns <- which(sampleColumns)
   sampleColumnsStartEnd <- c(min(sampleColumns), max(sampleColumns))
   
@@ -576,11 +585,12 @@ readProjectData <- function(fileLines, progress = FALSE)
   annoPresentColorsList <- list()
   annoPresentAnnotationsList[[1]] <- annotationValueIgnore
   annoPresentColorsList[[1]] <- annotationColorIgnore
-  if(length(annotationColorsMapKeys) > 0)
+  if(length(annotationColorsMapKeys) > 0) {
     for(i in seq_len(length(annotationColorsMapKeys))){
       annoPresentAnnotationsList[[1 + i]] <- annotationColorsMapKeys[[i]]
       annoPresentColorsList     [[1 + i]] <- annotationColorsMapValues[[i]]
     }
+  }
   
   ## check consistency
   if(!all(unique(unlist(annoArrayOfLists)) %in% unlist(annoPresentAnnotationsList))){
@@ -666,20 +676,24 @@ readProjectData <- function(fileLines, progress = FALSE)
     which(dataList$tagsSector == dataList$grouXXXps[[groupIdx]] & !(dataList$metaboliteProfileColumnNames %in% sampleNamesToExclude))
   }
   dataList$dataColumnIndecesFunctionFromGroupIndex <- dataColumnIndecesFunctionFromGroupIndex
+  
   dataColumnsNameFunctionFromGroupIndex <- function(groupIdx, sampleNamesToExclude){
     dataList$metaboliteProfileColumnNames[dataList$dataColumnIndecesFunctionFromGroupIndex(groupIdx = groupIdx, sampleNamesToExclude = sampleNamesToExclude)]
   }
   dataList$dataColumnsNameFunctionFromGroupIndex <- dataColumnsNameFunctionFromGroupIndex
+  
   dataColumnsNameFunctionFromGroupName <- function(group, sampleNamesToExclude){
     dataColumns <- dataList$dataColumnsNameFunctionFromGroupIndex(groupIdx = match(x = group, table = dataList$grouXXXps), sampleNamesToExclude = sampleNamesToExclude)
   }
   dataList$dataColumnsNameFunctionFromGroupName <- dataColumnsNameFunctionFromGroupName
+  
   dataColumnsNameFunctionFromGroupNames <- function(grouXXXps, sampleNamesToExclude){
     unlist(lapply(X = grouXXXps, FUN = function(x){
       dataList$dataColumnsNameFunctionFromGroupName(group = x, sampleNamesToExclude = sampleNamesToExclude)
     }))
   }
   dataList$dataColumnsNameFunctionFromGroupNames <- dataColumnsNameFunctionFromGroupNames
+  
   groupNameFunctionFromDataColumnName <- function(dataColumnName, sampleNamesToExclude){
     groupIdx <- which(unlist(lapply(X = dataList$grouXXXps, FUN = function(x){
       dataColumnNames <- dataList$dataColumnsNameFunctionFromGroupName(group = x, sampleNamesToExclude = sampleNamesToExclude)
@@ -706,6 +720,7 @@ readProjectData <- function(fileLines, progress = FALSE)
     return(samples[isExcluded & isGroup])
   }
   dataList$excludedSamples <- excludedSamples
+  
   includedSamples <- function(groupSampleDataFrame, grouXXXps = dataList$grouXXXps){
     samples    =  groupSampleDataFrame[, "Sample"]
     isIncluded = !groupSampleDataFrame[, "Exclude"]
@@ -720,6 +735,7 @@ readProjectData <- function(fileLines, progress = FALSE)
     })))
   }
   dataList$includedGroups <- includedGroups
+  
   excludedGroups <- function(groupSampleDataFrame, samples = dataList$groupSampleDataFrame[, "Sample"]){
     setdiff(dataList$grouXXXps, dataList$includedGroups(groupSampleDataFrame, samples)) 
   }

--- a/R/DataProcessing.R
+++ b/R/DataProcessing.R
@@ -802,8 +802,8 @@ add_qfeatures <- function(dataList, qfeatures, fileAnnotation) {
   # gp: removed red as it is already used for ignore category
   # TODO automate color generation, do not limit it to 40, could always use same colors, no need for sampling
   allowedCols <- c("blue", "yellow", "green", "brown", "deepskyblue", "orange", "deeppink", "aquamarine", "burlywood", "cadetblue", "coral", "cornflowerblue", "cyan", "firebrick", "goldenrod", "indianred", "khaki", "magenta", "maroon", "beige", "moccasin", "olivedrab", "orangered", "orchid", "paleturquoise3", "rosybrown", "salmon", "seagreen3", "skyblue", "steelblue", "#BF360C", "#33691E", "#311B92", "#880E4F", "#1A237E", "#006064", "#004D40", "#FF6F00", "#E65100")
-  # uniqueAnnotations <- paste0(uniqueAnnotations, sample(allowedCols, length(uniqueAnnotations), replace = TRUE))
-  uniqueAnnotations <- uniano
+  uniqueAnnotations <- paste0(uniqueAnnotations, sample(allowedCols, length(uniqueAnnotations), replace = TRUE))
+  
   # Format uniqueAnnotations into a single line with comma-separated values
   uniqueAnnotations1 <- paste(uniqueAnnotations, collapse = ", ")
   #uniqueAnnotationsHexs <- paste("AnnotationColors={", paste(uniqueAnnotations1, collapse = ","), "}")# this line introduces a space after the first Item of the object, therefore, replaced with the following to remove the space

--- a/R/DataProcessing.R
+++ b/R/DataProcessing.R
@@ -767,7 +767,7 @@ add_qfeatures <- function(dataList, qfeatures, fileAnnotation = NULL) {
     return(dataList)
   }
   
-  metaboliteProfile <- dataList$dataFrameInfos
+  qfeatures <- addSiriusAnnotations(qfeatures, fileAnnotation)
   
   # previously used test, not sure if still needed
   if (is.null(attr(rowData(qfeatures[[1]]), "annotation column"))) {
@@ -782,7 +782,7 @@ add_qfeatures <- function(dataList, qfeatures, fileAnnotation = NULL) {
   alignment_ids <- rowData(qfeatures[[1]])[["Alignment ID"]]
   
   # Find the matching indices between metaboliteProfile and annotation_data
-  
+  metaboliteProfile <- dataList$dataFrameInfos
   matching_indices <- match(metaboliteProfile[["Alignment ID"]], alignment_ids)
   
   metaboliteProfile$Annotation[!is.na(matching_indices)] <- annotation_data[matching_indices[!is.na(matching_indices)]] 

--- a/R/FragmentMatrixFunctions.R
+++ b/R/FragmentMatrixFunctions.R
@@ -1396,9 +1396,19 @@ mzClustGeneric <- function(p,
   return(list(mat=groupmat,idx=groupindex))
 }
 
+#' Convert to Project File
+#' 
+#' Reads and creates a list from separate files.
+#'
+#' @param filePeakMatrixPath path
+#' @param fileSpectra path
+#' @param parameterSet list of parameters
+#' @param progress logical
+#'
+#' @returns resultObj
+#' @export
 convertToProjectFile <- function(filePeakMatrixPath, 
                                  fileSpectra,
-                                 fileAnnotation,
                                  parameterSet, 
                                  progress = FALSE){
   ####################################################################################
@@ -1437,11 +1447,7 @@ convertToProjectFile <- function(filePeakMatrixPath,
   
   
   filePeakMatrixQF <- readMSDial(filePeakMatrixPath)
-  if (!is.null(fileAnnotation)){
-    # TODO: determine colums to merge by
-    filePeakMatrixQF <- addSiriusAnnotations(filePeakMatrixQF,fileAnnotation)
-  }
-  
+
   returnObj <- convertToProjectFile2(
     filePeakMatrixQF = filePeakMatrixQF, 
     spectraList = spectraList, precursorMz = precursorMz, precursorRt = precursorRt, 

--- a/inst/MetFamily/app_files/server_guiTabInput.R
+++ b/inst/MetFamily/app_files/server_guiTabInput.R
@@ -370,7 +370,7 @@ importData <- function(importMS1andMS2data){
         convertToProjectFile(
           filePeakMatrix = fileMs1Path, 
           fileSpectra = fileMs2Path, 
-          fileAnnotation = fileAnnotPath,
+          # fileAnnotation = fileAnnotPath,
           parameterSet = parameterSet, 
           progress = TRUE
         )
@@ -403,12 +403,14 @@ importData <- function(importMS1andMS2data){
   error <- NULL
   withProgress(message = 'Processing matrix...', value = 0, {
     lines <- sparseMatrixToString(matrixRows = resultObj$matrixRows, matrixCols = resultObj$matrixCols, matrixVals = resultObj$matrixVals, parameterSet = parameterSet)
-    qfeatures <- resultObj$qfeatures
+    # qfeatures <- resultObj$qfeatures
     #################################################
     ## process project file
     
     dataList <<- tryCatch({
-        readProjectData(fileLines = lines, progress = TRUE, qfeatures = qfeatures)
+        readProjectData(fileLines = lines, progress = TRUE) %>% 
+        add_qfeatures(qfeatures = resultObj$qfeatures,
+                      fileAnnotation = fileAnnotPath)
       }, error = function(e) {
         error <<- e
       }

--- a/vignettes/discoveringregulatedmetabolitefamilies.Rmd
+++ b/vignettes/discoveringregulatedmetabolitefamilies.Rmd
@@ -40,8 +40,7 @@ First, we load the data and summarise it
 
 ```{r load-data}
 
-#That's also what the shiny app uses
-dataList <<- list()
+# Load separate files
 
 filePeakMatrixPath <- system.file("extdata/showcase/Metabolite_profile_showcase.txt", package = "MetFamily")
 
@@ -54,16 +53,40 @@ load(parameterSetPath)
 
 resultObj <- convertToProjectFile(filePeakMatrixPath, 
                                  fileSpectra,
-                                 fileAnnotation,
-                                 parameterSet, 
+                                 parameterSet = parameterSet, 
                                  progress = FALSE)
   
-lines <- sparseMatrixToString(matrixRows = resultObj$matrixRows, matrixCols = resultObj$matrixCols, matrixVals = resultObj$matrixVals, parameterSet = parameterSet)
-qfeatures <- resultObj$qfeatures
-dataList <<- readProjectData(fileLines = lines, progress = FALSE, qfeatures = qfeatures)
-#project <- readClusterDataFromProjectFile(file = fileName)
+lines <- sparseMatrixToString(matrixRows = resultObj$matrixRows, matrixCols = resultObj$matrixCols,
+                              matrixVals = resultObj$matrixVals, parameterSet = parameterSet)
+
+dataList0 <- readProjectData(fileLines = lines, progress = FALSE)
+
 
 ```
+
+```{r}
+# add qfeatures
+
+dataList <- add_qfeatures(dataList0, qfeatures = resultObj$qfeatures, fileAnnotation)
+
+# *** gp: PR works until here to reproduce previous behavior with a simpler workflow
+
+
+```
+
+```{r eval=FALSE, include=FALSE}
+
+# use showcase for testing
+
+# fileName <- system.file("extdata/showcase/Project_file_showcase_annotated.csv.gz", package = "MetFamily")
+# project <- readClusterDataFromProjectFile(file = fileName)
+
+project$dataFrameMS1Header$Annotation
+dataList$dataFrameMS1Header$Annotation
+
+
+```
+
 
 # Filtering data
 
@@ -84,7 +107,7 @@ PCA on MS1 in Figure \@ref(fig:pca).
 fileName <- system.file("extdata/testdata/filterObj.Rdata", package = "MetFamily")
 load(fileName) 
 
-pca <- calculatePCA(dataList=dataList, 
+pca <- calculatePCA(dataList=dataList,
                          filterObj=filterObj, 
                          ms1AnalysisMethod="PCA (Principal Component Analysis)", 
                          scaling="None", 
@@ -106,6 +129,9 @@ pcaDimensionTwo <<- 2
     yInterval = NULL
 )
 
+  # undebug(calcPlotPCAloadings)
+  # undebug(getPrecursorColors)
+  
   resultObj <- calcPlotPCAloadings(
     pcaObj = pca, 
     dataList = dataList, #project, 
@@ -133,7 +159,7 @@ pcaDimensionTwo <<- 2
 
 HCA on MS2 in Figure \@ref(fig:hca). 
 
-```{r hca, fig.cap="HCA on MS2.", echo=FALSE}
+```{r hca, fig.cap="HCA on MS2.", echo=FALSE, eval=FALSE}
 
 if (FALSE) {
 p <- calcPlotDendrogram_plotly(dataList=dataList, #project, 
@@ -156,7 +182,7 @@ load(fileName)
 fileName <- system.file("extdata/testdata/hcaFilter.Rdata", package = "MetFamily")
 load(fileName) 
 
-returnObj <- calcPlotDendrogram(dataList=dataList, #project, 
+returnObj <- calcPlotDendrogram(dataList=dataList2, #project, 
                                 filter=filter, 
                                 clusterDataList=clusterDataList, 
                                 annoPresentAnnotationsList = annoPresentAnnotationsList ,


### PR DESCRIPTION
Implementation of a (slightly) simpler workflow  to add qfeatures that can more easily be built on. This PR removed code blocks from `convertToProjectFile()` and `readProjectData()` and created instead a new function `add_qfeatures()` to do the same work. Some additional bug fixes, formatting and documentation were also done.