### PR TITLE
Fix for unique sample class

### DIFF
--- a/R/Analysis.R
+++ b/R/Analysis.R
@@ -16,7 +16,7 @@ filterThreshold <- function(dataList, filter_average, sampleClasses = dataList$s
                           FUN = dataList$dataMeanColumnNameFunctionFromName)
   
   unname(
-    apply(X = dataList$dataFrameMeasurements[, mean_colnames],
+    apply(X = dataList$dataFrameMeasurements[, mean_colnames, drop = FALSE],
           MARGIN = 1, FUN = mean) >= filter_average
   )
   


### PR DESCRIPTION
There was an issue with dataset that only contained one sample class. This simple fix deals with that unusual use case.